### PR TITLE
Typo in GangZoneHideForAll

### DIFF
--- a/GZ_ShapesALS.inc
+++ b/GZ_ShapesALS.inc
@@ -400,7 +400,7 @@ stock GZ_ShapeHideForAll(shapeid)
 					continue;
 				}
 
-				GangZoneHideForAll(playerid, gzs_gInfo[shapeid][gzs_Elements][y]);
+				GangZoneHideForAll(gzs_gInfo[shapeid][gzs_Elements][y]);
 			}
 
 			return 1;


### PR DESCRIPTION
GangZoneHideForAll accepts only one variable, and by mistake a playerid was inserted as the first parameter.